### PR TITLE
fix(refs): exclude code block content from reference definition scanning

### DIFF
--- a/pkg/lint/refs/collector.go
+++ b/pkg/lint/refs/collector.go
@@ -298,8 +298,8 @@ var refDefPattern = regexp.MustCompile(
 
 // buildCodeBlockLines returns a set of line numbers that are inside code blocks.
 // These lines should be skipped when scanning for reference definitions.
-func (c *collector) buildCodeBlockLines() map[int]bool {
-	lines := make(map[int]bool)
+func (c *collector) buildCodeBlockLines() map[int]struct{} {
+	lines := make(map[int]struct{})
 	if c.root == nil {
 		return lines
 	}
@@ -310,7 +310,7 @@ func (c *collector) buildCodeBlockLines() map[int]bool {
 			pos := node.SourcePosition()
 			if pos.IsValid() {
 				for line := pos.StartLine; line <= pos.EndLine; line++ {
-					lines[line] = true
+					lines[line] = struct{}{}
 				}
 			}
 		}
@@ -331,7 +331,7 @@ func (c *collector) collectDefinitionsFromSource() {
 
 	for lineNum, lineInfo := range c.ctx.File.Lines {
 		// Skip lines inside code blocks (lineNum is 0-indexed, positions are 1-indexed)
-		if codeBlockLines[lineNum+1] {
+		if _, inCodeBlock := codeBlockLines[lineNum+1]; inCodeBlock {
 			continue
 		}
 

--- a/pkg/lint/refs/collector.go
+++ b/pkg/lint/refs/collector.go
@@ -15,7 +15,8 @@ func Collect(root *mdast.Node, file *mdast.FileSnapshot) *Context {
 	}
 
 	coll := &collector{
-		ctx: NewContext(file),
+		ctx:  NewContext(file),
+		root: root,
 	}
 	coll.collect(root)
 	coll.collectDefinitionsFromSource()
@@ -26,7 +27,8 @@ func Collect(root *mdast.Node, file *mdast.FileSnapshot) *Context {
 
 // collector builds a Context by walking the AST and source.
 type collector struct {
-	ctx *Context
+	ctx  *Context
+	root *mdast.Node
 }
 
 // collect walks the AST to collect anchors and usages.
@@ -294,13 +296,45 @@ var refDefPattern = regexp.MustCompile(
 	`^\s{0,3}\[([^\]]+)\]:\s*(\S+)(?:\s+"([^"]*)"|\s+'([^']*)'|\s+\(([^)]*)\))?\s*$`,
 )
 
+// buildCodeBlockLines returns a set of line numbers that are inside code blocks.
+// These lines should be skipped when scanning for reference definitions.
+func (c *collector) buildCodeBlockLines() map[int]bool {
+	lines := make(map[int]bool)
+	if c.root == nil {
+		return lines
+	}
+
+	//nolint:errcheck // Walk visitor never returns error in this usage
+	mdast.Walk(c.root, func(node *mdast.Node) error {
+		if node.Kind == mdast.NodeCodeBlock {
+			pos := node.SourcePosition()
+			if pos.IsValid() {
+				for line := pos.StartLine; line <= pos.EndLine; line++ {
+					lines[line] = true
+				}
+			}
+		}
+		return nil
+	})
+
+	return lines
+}
+
 // collectDefinitionsFromSource parses reference definitions from the source.
 func (c *collector) collectDefinitionsFromSource() {
 	if c.ctx.File == nil || len(c.ctx.File.Content) == 0 {
 		return
 	}
 
+	// Build set of lines inside code blocks - these cannot contain reference definitions
+	codeBlockLines := c.buildCodeBlockLines()
+
 	for lineNum, lineInfo := range c.ctx.File.Lines {
+		// Skip lines inside code blocks (lineNum is 0-indexed, positions are 1-indexed)
+		if codeBlockLines[lineNum+1] {
+			continue
+		}
+
 		line := c.ctx.File.Content[lineInfo.StartOffset:lineInfo.NewlineStart]
 		matches := refDefPattern.FindSubmatch(line)
 		if matches == nil {

--- a/pkg/lint/rules/testdata/MD053/code-block-exclusion.diags.json
+++ b/pkg/lint/rules/testdata/MD053/code-block-exclusion.diags.json
@@ -1,0 +1,11 @@
+[
+  {
+    "rule": "MD053",
+    "name": "",
+    "line": 35,
+    "column": 1,
+    "message": "Unused reference definition [unused-ref]",
+    "severity": "warning",
+    "fixable": false
+  }
+]

--- a/pkg/lint/rules/testdata/MD053/code-block-exclusion.diags.txt
+++ b/pkg/lint/rules/testdata/MD053/code-block-exclusion.diags.txt
@@ -1,0 +1,1 @@
+code-block-exclusion.input.md:35:1 warning Unused reference definition [unused-ref] ()

--- a/pkg/lint/rules/testdata/MD053/code-block-exclusion.golden.md
+++ b/pkg/lint/rules/testdata/MD053/code-block-exclusion.golden.md
@@ -1,0 +1,35 @@
+# Reference Definitions in Code Blocks
+
+This test verifies that reference-definition-like patterns inside code blocks
+are not mistakenly flagged as markdown reference definitions.
+
+## JavaScript Example
+
+```javascript
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+
+const resource = Resource.default().merge(new Resource({
+  [SemanticResourceAttributes.SERVICE_NAME]: 'my-app',
+  [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+}));
+```
+
+## Python Example
+
+```python
+config = {
+    [key]: value
+    for key, value in items.items()
+}
+```
+
+## Valid Reference Usage
+
+Here is a [link to example][example-ref].
+
+[example-ref]: https://example.com
+
+## Unused Reference (should be flagged)
+
+[unused-ref]: https://unused.example.com

--- a/pkg/lint/rules/testdata/MD053/code-block-exclusion.input.md
+++ b/pkg/lint/rules/testdata/MD053/code-block-exclusion.input.md
@@ -1,0 +1,35 @@
+# Reference Definitions in Code Blocks
+
+This test verifies that reference-definition-like patterns inside code blocks
+are not mistakenly flagged as markdown reference definitions.
+
+## JavaScript Example
+
+```javascript
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+
+const resource = Resource.default().merge(new Resource({
+  [SemanticResourceAttributes.SERVICE_NAME]: 'my-app',
+  [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+}));
+```
+
+## Python Example
+
+```python
+config = {
+    [key]: value
+    for key, value in items.items()
+}
+```
+
+## Valid Reference Usage
+
+Here is a [link to example][example-ref].
+
+[example-ref]: https://example.com
+
+## Unused Reference (should be flagged)
+
+[unused-ref]: https://unused.example.com


### PR DESCRIPTION
Fixes #3

## Summary

- Fix bug where JavaScript/Python code inside fenced code blocks was incorrectly detected as markdown reference definitions
- Reported by @preminger: patterns like `[SemanticResourceAttributes.SERVICE_NAME]: 'value'` were flagged as "Unused reference definition"

## Changes

- Added `buildCodeBlockLines()` to identify lines inside code blocks by walking the AST
- Modified `collectDefinitionsFromSource()` to skip those lines when scanning for reference definitions
- Uses idiomatic `map[int]struct{}` for the line set (zero memory overhead for values)

## Design Note

The fix introduces a second AST walk (in addition to the existing `collect()` walk). This was intentional:

- **Walk 1 (`collect`)**: Builds persistent reference context (anchors, usages)
- **Walk 2 (`buildCodeBlockLines`)**: Builds temporary filter for source-based definition scanning

Kept separate because: different concerns, different lifetimes (filter is discarded immediately), and code blocks don't contribute to the reference model - they're exclusion zones. For typical markdown files, the performance difference is negligible.

## Test plan

- [x] Unit test `TestCollect_IgnoresCodeBlockContent` verifies code block exclusion
- [x] Golden test `MD053/code-block-exclusion` covers JavaScript and Python examples
- [x] All 1681 tests pass
- [x] golangci-lint passes with 0 issues