### PR TITLE
Add missing MD051 golden test files

### DIFF
--- a/pkg/lint/rules/testdata/MD051/external-urls.diags.txt
+++ b/pkg/lint/rules/testdata/MD051/external-urls.diags.txt
@@ -1,0 +1,1 @@
+external-urls.input.md:27:4 warning Link fragment '#nonexistent-heading' does not match any heading ()


### PR DESCRIPTION
Noticed these two `.diags.txt` files were sitting in my working directory untracked - looks like they got generated at some point but never made it into the repo.

Adding them now so the golden test suite stays complete.

## Changes

- `code-span-headings.diags.txt` - empty (no diagnostics expected for that test case)
- `external-urls.diags.txt` - one diagnostic for a broken internal fragment link

Nothing exciting, just housekeeping.