### PR TITLE
Fix diff reporter paths and MD032 false positive with fenced code

### DIFF
--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -148,7 +148,7 @@ func (ctx *analysisContext) buildByRule(opts Options) []RuleAnalysis {
 
 // buildByFile constructs the ByFile slice from accumulated data.
 func (ctx *analysisContext) buildByFile(opts Options) []FileAnalysis {
-	var result []FileAnalysis
+	result := make([]FileAnalysis, 0, len(ctx.fileMap))
 	for path, fa := range ctx.fileMap {
 		if fa.Issues == 0 {
 			continue

--- a/pkg/lint/rules/emphasis.go
+++ b/pkg/lint/rules/emphasis.go
@@ -45,7 +45,7 @@ func (r *NoEmphasisAsHeadingRule) Apply(ctx *lint.RuleContext) ([]lint.Diagnosti
 	punctuation := ctx.OptionString("punctuation", defaultEmphasisPunctuation)
 
 	paragraphs := ctx.Paragraphs()
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(paragraphs))
 
 	for _, para := range paragraphs {
 		if ctx.Cancelled() {

--- a/pkg/lint/rules/headings_extended.go
+++ b/pkg/lint/rules/headings_extended.go
@@ -569,8 +569,8 @@ func (r *NoDuplicateHeadingRule) checkSiblings(ctx *lint.RuleContext, headings [
 		text  string
 	}
 
-	var diags []lint.Diagnostic
-	var parentStack []parentInfo
+	diags := make([]lint.Diagnostic, 0, len(headings))
+	parentStack := make([]parentInfo, 0, len(headings))
 
 	// Map from (level, parent_path) -> (text -> first_heading)
 	seen := make(map[string]map[string]*mdast.Node)
@@ -661,7 +661,7 @@ func (r *NoTrailingPunctuationRule) Apply(ctx *lint.RuleContext) ([]lint.Diagnos
 	}
 
 	headings := ctx.Headings()
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(headings))
 
 	for _, heading := range headings {
 		if ctx.Cancelled() {

--- a/pkg/lint/rules/links.go
+++ b/pkg/lint/rules/links.go
@@ -123,7 +123,7 @@ func (r *LinkSpacesRule) Apply(ctx *lint.RuleContext) ([]lint.Diagnostic, error)
 	}
 
 	links := ctx.Links()
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(links))
 
 	for _, link := range links {
 		if ctx.Cancelled() {
@@ -189,7 +189,7 @@ func (r *EmptyLinkRule) Apply(ctx *lint.RuleContext) ([]lint.Diagnostic, error) 
 	}
 
 	links := ctx.Links()
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(links))
 
 	for _, link := range links {
 		if ctx.Cancelled() {
@@ -251,7 +251,7 @@ func (r *ImageAltTextRule) Apply(ctx *lint.RuleContext) ([]lint.Diagnostic, erro
 	}
 
 	images := ctx.Images()
-	var diags []lint.Diagnostic
+	diags := make([]lint.Diagnostic, 0, len(images))
 
 	for _, img := range images {
 		if ctx.Cancelled() {

--- a/pkg/lint/rules/lists_extended.go
+++ b/pkg/lint/rules/lists_extended.go
@@ -490,7 +490,11 @@ func (r *BlanksAroundListsRule) checkLazyContinuation(
 	return r.createAfterDiagnostic(ctx, itemPos.StartLine)
 }
 
-// checkBlankAfterNormal checks for missing blank line after list using next sibling position.
+// checkBlankAfterNormal checks for missing blank line after list using the list's end position.
+// We check the line immediately after the list ends (pos.EndLine + 1), mirroring
+// how checkBlankBefore checks pos.StartLine - 1. This avoids false positives when
+// the next sibling's SourcePosition excludes structural markers (e.g., fenced code
+// blocks report content start, not the opening fence line).
 func (r *BlanksAroundListsRule) checkBlankAfterNormal(
 	ctx *lint.RuleContext,
 	list *mdast.Node,
@@ -500,9 +504,9 @@ func (r *BlanksAroundListsRule) checkBlankAfterNormal(
 		return nil
 	}
 
-	// Find the line we need to check for blankness.
-	checkLine := r.findCheckLineForAfter(ctx, list)
-	if checkLine <= 0 || checkLine > len(ctx.File.Lines) || lint.IsBlankLine(ctx.File, checkLine) {
+	// Check the line immediately after the list ends.
+	checkLine := pos.EndLine + 1
+	if checkLine > len(ctx.File.Lines) || lint.IsBlankLine(ctx.File, checkLine) {
 		return nil
 	}
 
@@ -515,25 +519,6 @@ func (r *BlanksAroundListsRule) checkBlankAfterNormal(
 	}
 
 	return r.createAfterDiagnostic(ctx, diagLine)
-}
-
-// findCheckLineForAfter determines which line to check for blankness after the list.
-func (r *BlanksAroundListsRule) findCheckLineForAfter(ctx *lint.RuleContext, list *mdast.Node) int {
-	nextPos := list.Next.SourcePosition()
-	if nextPos.IsValid() && nextPos.StartLine > 1 {
-		// Next sibling has valid position - check line before it.
-		return nextPos.StartLine - 1
-	}
-
-	// Next sibling has invalid position (e.g., ThematicBreak with L0-L0).
-	// Fall back to checking the line after the last list item's marker.
-	if lastItem := list.LastChild; lastItem != nil {
-		if itemPos := lastItem.SourcePosition(); itemPos.IsValid() && itemPos.StartLine < len(ctx.File.Lines) {
-			return itemPos.StartLine + 1
-		}
-	}
-
-	return 0
 }
 
 // createAfterDiagnostic creates a diagnostic for missing blank line after list.

--- a/pkg/lint/rules/testdata/MD032/fenced-code-after-list.diags.json
+++ b/pkg/lint/rules/testdata/MD032/fenced-code-after-list.diags.json
@@ -1,0 +1,11 @@
+[
+  {
+    "rule": "MD032",
+    "name": "",
+    "line": 26,
+    "column": 1,
+    "message": "Missing blank line after list",
+    "severity": "warning",
+    "fixable": true
+  }
+]

--- a/pkg/lint/rules/testdata/MD032/fenced-code-after-list.diags.txt
+++ b/pkg/lint/rules/testdata/MD032/fenced-code-after-list.diags.txt
@@ -1,0 +1,1 @@
+fenced-code-after-list.input.md:26:1 warning Missing blank line after list () [fixable]

--- a/pkg/lint/rules/testdata/MD032/fenced-code-after-list.golden.md
+++ b/pkg/lint/rules/testdata/MD032/fenced-code-after-list.golden.md
@@ -1,0 +1,30 @@
+# Fenced Code After List
+
+Some text:
+
+- `Foo` -- `bar.Foo`
+- `Baz` -- `qux.Baz`
+
+```mermaid
+graph TD
+    A --> B
+```
+
+Another list with code fence:
+
+1. First item
+2. Second item
+
+```go
+// Some code
+func main() {}
+```
+
+List without blank line before code fence:
+
+- Item A
+- Item B
+
+```yaml
+key: value
+```

--- a/pkg/lint/rules/testdata/MD032/fenced-code-after-list.input.md
+++ b/pkg/lint/rules/testdata/MD032/fenced-code-after-list.input.md
@@ -1,0 +1,29 @@
+# Fenced Code After List
+
+Some text:
+
+- `Foo` -- `bar.Foo`
+- `Baz` -- `qux.Baz`
+
+```mermaid
+graph TD
+    A --> B
+```
+
+Another list with code fence:
+
+1. First item
+2. Second item
+
+```go
+// Some code
+func main() {}
+```
+
+List without blank line before code fence:
+
+- Item A
+- Item B
+```yaml
+key: value
+```

--- a/pkg/reporter/diff.go
+++ b/pkg/reporter/diff.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -69,7 +68,7 @@ func (r *DiffReporter) Report(_ context.Context, result *runner.Result) (int, er
 // writeDiff outputs a single file's diff with formatting.
 func (r *DiffReporter) writeDiff(diff *fix.Diff) {
 	// Use relative path for display if possible.
-	displayPath := relativePath(diff.Path)
+	displayPath := r.displayPath(diff.Path)
 
 	// Git-style header: "diff --git a/file b/file"
 	header := fmt.Sprintf("diff --git a/%s b/%s", displayPath, displayPath)
@@ -91,24 +90,39 @@ func (r *DiffReporter) writeDiff(diff *fix.Diff) {
 	fmt.Fprintln(r.out) // Blank line between files
 }
 
-// relativePath converts an absolute path to a relative path from the current directory.
-// If the relative path would require too many "../" traversals, use the basename instead.
-func relativePath(path string) string {
+// displayPath converts an absolute path to a relative path from the configured
+// working directory. It resolves symlinks on both sides to handle mount points
+// and volume aliases (e.g., /Volumes/Code vs /Users/.../Code on macOS).
+// Falls back to the original path (not just the basename) to preserve
+// directory context needed for unambiguous patch application.
+func (r *DiffReporter) displayPath(path string) string {
 	if !filepath.IsAbs(path) {
 		return path
 	}
-	cwd, err := os.Getwd()
+
+	workDir := r.opts.WorkingDir
+	if workDir == "" {
+		// Strip leading slash so diff prefix (a/, b/) doesn't produce a//path.
+		return strings.TrimPrefix(path, "/")
+	}
+
+	// Resolve symlinks on both sides so paths through mount points
+	// or symlinks compare correctly.
+	resolvedDir, err := filepath.EvalSymlinks(workDir)
 	if err != nil {
-		return filepath.Base(path)
+		resolvedDir = workDir
 	}
-	rel, err := filepath.Rel(cwd, path)
+	resolvedPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return filepath.Base(path)
+		resolvedPath = path
 	}
-	// If relative path has too many parent traversals, just use basename.
-	if strings.Count(rel, "..") > 2 {
-		return filepath.Base(path)
+
+	rel, err := filepath.Rel(resolvedDir, resolvedPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		// File is outside working directory — keep the full path.
+		return strings.TrimPrefix(path, "/")
 	}
+
 	return rel
 }
 

--- a/pkg/reporter/diff_test.go
+++ b/pkg/reporter/diff_test.go
@@ -1,0 +1,220 @@
+package reporter_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaklabco/gomdlint/pkg/fix"
+	"github.com/yaklabco/gomdlint/pkg/lint"
+	"github.com/yaklabco/gomdlint/pkg/reporter"
+	"github.com/yaklabco/gomdlint/pkg/runner"
+)
+
+func TestDiffReporter_PreservesSubdirectoryInPath(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	subDir := filepath.Join(workDir, "docs", "guide")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	absPath := filepath.Join(subDir, "file.md")
+	require.NoError(t, os.WriteFile(absPath, []byte("# Test\n\nold line\n"), 0o644))
+
+	original := []byte("# Test\n\nold line\n")
+	modified := []byte("# Test\n\nnew line\n")
+	diff := fix.GenerateDiff(absPath, original, modified)
+	require.NotNil(t, diff)
+
+	var buf bytes.Buffer
+	rep := reporter.NewDiffReporter(reporter.Options{
+		Writer:     &buf,
+		Color:      "never",
+		WorkingDir: workDir,
+	})
+
+	result := &runner.Result{
+		Files: []runner.FileOutcome{{
+			Path: absPath,
+			Result: &lint.PipelineResult{
+				FileResult: &lint.FileResult{},
+				Diff:       diff,
+			},
+		}},
+	}
+
+	count, err := rep.Report(context.Background(), result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	output := buf.String()
+	assert.Contains(t, output, "docs/guide/file.md",
+		"diff output should preserve subdirectory path")
+	assert.Contains(t, output, "diff --git a/docs/guide/file.md b/docs/guide/file.md")
+	assert.Contains(t, output, "--- a/docs/guide/file.md")
+	assert.Contains(t, output, "+++ b/docs/guide/file.md")
+}
+
+func TestDiffReporter_FallsBackToFullPathNotBasename(t *testing.T) {
+	t.Parallel()
+
+	// When the file is outside the working directory, the full path should be
+	// preserved rather than being stripped to just the basename.
+	workDir := t.TempDir()
+	otherDir := t.TempDir()
+	subDir := filepath.Join(otherDir, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	absPath := filepath.Join(subDir, "file.md")
+	require.NoError(t, os.WriteFile(absPath, []byte("# Test\n\nold line\n"), 0o644))
+
+	original := []byte("# Test\n\nold line\n")
+	modified := []byte("# Test\n\nnew line\n")
+	diff := fix.GenerateDiff(absPath, original, modified)
+	require.NotNil(t, diff)
+
+	var buf bytes.Buffer
+	rep := reporter.NewDiffReporter(reporter.Options{
+		Writer:     &buf,
+		Color:      "never",
+		WorkingDir: workDir,
+	})
+
+	result := &runner.Result{
+		Files: []runner.FileOutcome{{
+			Path: absPath,
+			Result: &lint.PipelineResult{
+				FileResult: &lint.FileResult{},
+				Diff:       diff,
+			},
+		}},
+	}
+
+	count, err := rep.Report(context.Background(), result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	output := buf.String()
+	// Must NOT strip to just "file.md" — should retain enough path to be unambiguous.
+	assert.NotContains(t, output, "diff --git a/file.md b/file.md",
+		"should not strip path to bare filename")
+	assert.Contains(t, output, "sub/file.md",
+		"should retain at least the parent directory")
+}
+
+func TestDiffReporter_SymlinkedWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	// Create a real dir and a symlink to it.
+	realDir := t.TempDir()
+	docsDir := filepath.Join(realDir, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o755))
+	absPath := filepath.Join(docsDir, "file.md")
+	require.NoError(t, os.WriteFile(absPath, []byte("# Test\n\nold line\n"), 0o644))
+
+	symlinkDir := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realDir, symlinkDir); err != nil {
+		t.Skip("cannot create symlinks:", err)
+	}
+
+	original := []byte("# Test\n\nold line\n")
+	modified := []byte("# Test\n\nnew line\n")
+	diff := fix.GenerateDiff(absPath, original, modified)
+	require.NotNil(t, diff)
+
+	var buf bytes.Buffer
+	// WorkingDir is the symlink, but the file path uses the real directory.
+	rep := reporter.NewDiffReporter(reporter.Options{
+		Writer:     &buf,
+		Color:      "never",
+		WorkingDir: symlinkDir,
+	})
+
+	result := &runner.Result{
+		Files: []runner.FileOutcome{{
+			Path: absPath,
+			Result: &lint.PipelineResult{
+				FileResult: &lint.FileResult{},
+				Diff:       diff,
+			},
+		}},
+	}
+
+	count, err := rep.Report(context.Background(), result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	output := buf.String()
+	assert.Contains(t, output, "docs/file.md",
+		"should resolve symlinks and produce correct relative path")
+}
+
+func TestDiffReporter_EmptyWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	absPath := "/some/absolute/path/file.md"
+
+	original := []byte("# Test\n\nold line\n")
+	modified := []byte("# Test\n\nnew line\n")
+	diff := fix.GenerateDiff(absPath, original, modified)
+	require.NotNil(t, diff)
+
+	var buf bytes.Buffer
+	rep := reporter.NewDiffReporter(reporter.Options{
+		Writer:     &buf,
+		Color:      "never",
+		WorkingDir: "", // empty — should keep full path
+	})
+
+	result := &runner.Result{
+		Files: []runner.FileOutcome{{
+			Path: absPath,
+			Result: &lint.PipelineResult{
+				FileResult: &lint.FileResult{},
+				Diff:       diff,
+			},
+		}},
+	}
+
+	count, err := rep.Report(context.Background(), result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	output := buf.String()
+	// With no WorkingDir, should use the path as-is (minus leading slash for diff prefix).
+	assert.Contains(t, output, "some/absolute/path/file.md",
+		"with empty WorkingDir, should preserve the full path")
+}
+
+func TestDiffReporter_RelativePath(t *testing.T) {
+	t.Parallel()
+
+	// When the path is already relative, it should be used as-is.
+	diff := fix.GenerateDiff("docs/file.md", []byte("old\n"), []byte("new\n"))
+	require.NotNil(t, diff)
+
+	var buf bytes.Buffer
+	rep := reporter.NewDiffReporter(reporter.Options{
+		Writer:     &buf,
+		Color:      "never",
+		WorkingDir: "/whatever",
+	})
+
+	result := &runner.Result{
+		Files: []runner.FileOutcome{{
+			Path: "docs/file.md",
+			Result: &lint.PipelineResult{
+				FileResult: &lint.FileResult{},
+				Diff:       diff,
+			},
+		}},
+	}
+
+	count, err := rep.Report(context.Background(), result)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Contains(t, buf.String(), "docs/file.md")
+}


### PR DESCRIPTION
## Summary

- **fix(reporter):** Diff output now preserves subdirectory paths instead of stripping them to basename. The `relativePath()` helper was replaced with a `displayPath()` method that uses the existing `Options.WorkingDir` field and resolves macOS mount-point symlinks (`/Volumes/Code` vs `/Users/.../Code`) via `filepath.EvalSymlinks`.
- **fix(MD032):** False positive when a list immediately precedes a fenced code block (Fixes #15). Goldmark reports fenced code `SourcePosition.StartLine` at the content line, not the opening fence — so `checkBlankAfterNormal` now checks `pos.EndLine + 1` (anchored to the list) instead of `nextPos.StartLine - 1` (dependent on next sibling semantics). This aligns with how MD022, MD031, and MD060 handle the same check.
- **fix(lint):** Pre-allocate slices flagged by the `prealloc` linter across `pkg/analysis`, `pkg/lint/rules/emphasis.go`, `pkg/lint/rules/headings_extended.go`, and `pkg/lint/rules/links.go`.

## Test plan

- [x] New `pkg/reporter/diff_test.go` with 5 test cases covering subdirectory paths, symlinks, empty WorkingDir, relative paths, and fallback behavior
- [x] New golden test `MD032/fenced-code-after-list` covering list+fenced code with blank line (no diagnostic), ordered list variant, and list+fenced code without blank line (diagnostic fires)
- [x] Pressure tested MD032 fix across 11 edge cases (EOF, thematic break, heading, blockquote, nested lists, HTML blocks, lazy continuation, sandwiched fences)
- [x] Verified architectural consistency with MD022, MD031, MD060 — all use `pos.EndLine + 1` pattern
- [x] All 2059 tests pass, pre-commit and pre-push hooks pass